### PR TITLE
Larger existing destination files not overwritten properly

### DIFF
--- a/cmsfscp.c
+++ b/cmsfscp.c
@@ -46,7 +46,7 @@ int main(int argc,unsigned char *argv[])
     struct  stat  targstat;
 
     cmsflags = CMSFSANY;
-    stdflags = O_RDWR|O_CREAT;
+    stdflags = O_RDWR|O_CREAT|O_TRUNC;
     source = target = devname = (unsigned char *) "";
     /*  DRAT COMPILERS THAT DON'T GROK UNSIGNED CHAR!  */
 


### PR DESCRIPTION
When using cmsfscp to copy to an existing file, the contents
of the destination file are not truncated. Therefore, if
the destination file is larger than the source file, you
will have unwanted trailing data remaining in the file
after the copy. This one-liner adds the O_TRUNC flag to
the open() syscall to address this problem.